### PR TITLE
fix: 给 settings.plugin.item 注册项补 options.id

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -73,12 +73,14 @@ export function apply(ctx: ClientContext): void {
   // Plugin configuration card: one staged form over the `auto-continue`
   // settings namespace, contributed to the plugin-configuration section
   // (Settings → Plugins). Since DSH 0.1.0-rc.7 `settings.plugin.item` is a
-  // keyed slot dispatched by the settings namespace it edits, so the entry
-  // registers with `key` (the namespace), like the official cards.
+  // keyed slot dispatched by the settings namespace it edits; the entry
+  // registers with `id` (which the host uses to dedupe and address the slot
+  // item) and `key` (the namespace being edited), like the official cards.
   const controller = new AutoContinueSettingsCardController(scope);
   ctx.slots.inject('settings.plugin.item', () =>
     ctx.slots.register(
       {
+        id: SETTINGS_NS,
         name: 'settings.plugin.item',
         key: SETTINGS_NS,
         locale: NS,


### PR DESCRIPTION
## 背景

加载插件时，控制台报：

```
Failed to load plugins
dsh-client-auto-continue
failed to apply loader entry c80392eb (dsh-client-auto-continue):
  list slot "settings.plugin.item" requires options.id
```

也就是更新的 DSH host 把 `settings.plugin.item` 升级为列表 slot（list slot），每条 entry 必须带 `options.id` 才能被 loader 校验通过、才能去重/寻址。

## 现有实现

`src/client/index.ts` 的 `apply(ctx)` 里：

```ts
ctx.slots.inject('settings.plugin.item', () =>
  ctx.slots.register(
    {
      name: 'settings.plugin.item',
      key: SETTINGS_NS,   // ← 只有 key，没有 id
      locale: NS,
      inject: () => controller.inject(),
    },
    AutoContinueSettingsCard,
  ),
);
```

历史的 `3ba1acd fix: register settings.plugin.item with key for DSH rc.7 (keyed slot)` 只补了 `key`，但当时 DSH 0.1.0-rc.7 的 host 还没把 `id` 列为必填项，更新的 host 改成了"keyed + id 必填"的列表 slot，所以这个 entry 在新 host 上被拒绝。

## 修复

在 `slots.register` 的 options 里同时保留 `key`（旧的 keyed 派发继续可用，兼容老 host）并新增 `id: SETTINGS_NS`（即 `'auto-continue'`，满足新 host 的 id 必填校验）：

```ts
ctx.slots.inject('settings.plugin.item', () =>
  ctx.slots.register(
    {
      id: SETTINGS_NS,                    // ← 新增：满足 list slot 对 options.id 的要求
      name: 'settings.plugin.item',
      key: SETTINGS_NS,                   // ← 保留：老 host 仍按 keyed 派发
      locale: NS,
      inject: () => controller.inject(),
    },
    AutoContinueSettingsCard,
  ),
);
```

`name` / `key` / `locale` / `inject` 都不变，老 DSH 行为兼容。

## 影响范围

- 仅 `src/client/index.ts` 一处。
- `lib/client.js` 是 `tsc -p tsconfig.build.json` 的产物，本 PR 不直接改动；维护者合并前跑 `npm run build` 重新生成即可。

## 验证

- 报错的 DSH profile（`profiles/web`）下，loader entry `c80392eb` 加载通过，`settings.plugin.item` 列表里出现 `auto-continue` 卡片。
- 我已经在自己的 `profiles/web/node_modules/dsh-client-auto-continue` 同步应用了同样的补丁（src + lib 都改了），loader 报错消失，插件正常注册。

## Checklist

- [x] 只改 `src/client/index.ts`，编译产物由上游 `npm run build` 重新生成
- [x] 与 `3ba1acd` 的 commit 兼容（保留 `key`）
- [x] 单文件改动，行为向后兼容

## Summary by Sourcery

Bug Fixes:
- 为 settings.plugin.item 注册项补充必需的 options.id，修复插件在新版 DSH host 上加载失败的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 为 settings.plugin.item 注册项补充必需的 options.id，修复插件在新版 DSH host 上加载失败的问题。

</details>