### PR TITLE
fix: dispose runner on fiber teardown to prevent host process crash on hot reload

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -317,7 +317,10 @@ var AutoContinueRunner = class {
     this.noticeListeners = /* @__PURE__ */ new Set();
     this.stateListeners = /* @__PURE__ */ new Set();
     this.disposed = false;
-    ctx.on("session/event", (session, event) => this.onHostEvent(session, event));
+    this.disposeSessionEvents = ctx.on(
+      "session/event",
+      (session, event) => this.onHostEvent(session, event)
+    );
     const config = this.getConfig();
     if (config.scanOnBoot) {
       void this.bootScanLoop();
@@ -379,7 +382,9 @@ var AutoContinueRunner = class {
     this.emitState();
   }
   dispose() {
+    if (this.disposed) return;
     this.disposed = true;
+    this.disposeSessionEvents();
     for (const state of this.states.values()) {
       if (state.pendingTimer !== void 0) clearTimeout(state.pendingTimer);
       if (state.loopRetryTimer !== void 0) clearTimeout(state.loopRetryTimer);

--- a/lib/index.js
+++ b/lib/index.js
@@ -560,7 +560,11 @@ ${event.data.arguments}`;
               if (state.loopRetryTimer !== void 0) clearTimeout(state.loopRetryTimer);
               state.loopRetryTimer = setTimeout(() => {
                 state.loopRetryTimer = void 0;
-                this.schedule(sessionId, "loop:aborted");
+                try {
+                  this.schedule(sessionId, "loop:aborted");
+                } catch (error) {
+                  console.error(`[auto-continue] loop 重启异常 ${sessionId}: ${error instanceof Error ? error.message : String(error)}`);
+                }
               }, remaining);
               this.log(`loop 重启延迟 ${remaining}ms(冷却期) ${sessionId}`);
             } else {
@@ -691,7 +695,11 @@ ${event.data.arguments}`;
       clearTimeout(state.pendingTimer);
       state.pendingTimer = void 0;
     }
-    await this.fire(sessionId, "manual:notification", true);
+    try {
+      await this.fire(sessionId, "manual:notification", true);
+    } catch (error) {
+      console.error(`[auto-continue] 手动续跑异常 ${sessionId}: ${error instanceof Error ? error.message : String(error)}`);
+    }
   }
   /** 本会话当前生效的冷却间隔(自适应退避)。 */
   cooldownFor(state) {
@@ -726,7 +734,11 @@ ${event.data.arguments}`;
     const timer = setTimeout(() => {
       if (state.pendingTimer !== timer) return;
       state.pendingTimer = void 0;
-      void this.fire(sessionId, reason);
+      try {
+        void this.fire(sessionId, reason);
+      } catch (error) {
+        console.error(`[auto-continue] 定时发送异常 ${sessionId}: ${error instanceof Error ? error.message : String(error)}`);
+      }
     }, config.graceMs);
     state.pendingTimer = timer;
     const template = reason.startsWith("loop:") ? config.loopText : reason.includes("max-tokens") ? config.continueTextMaxTokens : config.continueText;
@@ -992,11 +1004,14 @@ function apply(ctx) {
       applies: "live"
     });
   });
+  let runnerRef;
   ctx.inject(["settings", "agents", "webServer"], (engineCtx) => {
+    if (runnerRef !== void 0) runnerRef.dispose();
     const runner = new AutoContinueRunner(
       engineCtx,
       () => resolveConfig(engineCtx.settings.get(settingsNamespace(AUTO_CONTINUE_NS)))
     );
+    runnerRef = runner;
     const sseClients = /* @__PURE__ */ new Set();
     const pushToAll = (data) => {
       for (const send of sseClients) {
@@ -1070,6 +1085,11 @@ function apply(ctx) {
         });
       }
     });
+  });
+  ctx.effect(() => () => {
+    const runner = runnerRef;
+    runnerRef = void 0;
+    if (runner !== void 0) runner.dispose();
   });
 }
 export {

--- a/lib/types/host/engine.d.ts
+++ b/lib/types/host/engine.d.ts
@@ -36,6 +36,7 @@ export declare class AutoContinueRunner {
     private readonly notices;
     private readonly noticeListeners;
     private readonly stateListeners;
+    private readonly disposeSessionEvents;
     private disposed;
     /**
      * @param ctx - host plugin context (agents registry, session events, settings).

--- a/src/host/engine.ts
+++ b/src/host/engine.ts
@@ -434,7 +434,11 @@ export class AutoContinueRunner {
               if (state.loopRetryTimer !== undefined) clearTimeout(state.loopRetryTimer);
               state.loopRetryTimer = setTimeout(() => {
                 state.loopRetryTimer = undefined;
-                this.schedule(sessionId, 'loop:aborted');
+                try {
+                  this.schedule(sessionId, 'loop:aborted');
+                } catch (error) {
+                  console.error(`[auto-continue] loop 重启异常 ${sessionId}: ${error instanceof Error ? error.message : String(error)}`);
+                }
               }, remaining);
               this.log(`loop 重启延迟 ${remaining}ms(冷却期) ${sessionId}`);
             } else {
@@ -591,7 +595,11 @@ export class AutoContinueRunner {
       clearTimeout(state.pendingTimer);
       state.pendingTimer = undefined;
     }
-    await this.fire(sessionId, 'manual:notification', true);
+    try {
+      await this.fire(sessionId, 'manual:notification', true);
+    } catch (error) {
+      console.error(`[auto-continue] 手动续跑异常 ${sessionId}: ${error instanceof Error ? error.message : String(error)}`);
+    }
   }
 
   /** 本会话当前生效的冷却间隔(自适应退避)。 */
@@ -628,7 +636,12 @@ export class AutoContinueRunner {
     const timer = setTimeout(() => {
       if (state.pendingTimer !== timer) return;
       state.pendingTimer = undefined;
-      void this.fire(sessionId, reason);
+      // 保险丝: 定时器回调内任何异常(含 inactive context)都不得成为未捕获异常炸掉进程。
+      try {
+        void this.fire(sessionId, reason);
+      } catch (error) {
+        console.error(`[auto-continue] 定时发送异常 ${sessionId}: ${error instanceof Error ? error.message : String(error)}`);
+      }
     }, config.graceMs);
     state.pendingTimer = timer;
     const template = reason.startsWith('loop:')

--- a/src/host/engine.ts
+++ b/src/host/engine.ts
@@ -143,6 +143,7 @@ export class AutoContinueRunner {
   private readonly notices: HostNotice[] = [];
   private readonly noticeListeners = new Set<() => void>();
   private readonly stateListeners = new Set<() => void>();
+  private readonly disposeSessionEvents: () => void;
   private disposed = false;
 
   /**
@@ -154,7 +155,9 @@ export class AutoContinueRunner {
     private readonly getConfig: () => AutoContinueConfig,
   ) {
     // 单实例事件源: 宿主进程内的会话事件 firehose, 天然覆盖所有会话。
-    ctx.on('session/event', (session, event) => this.onHostEvent(session, event));
+    this.disposeSessionEvents = ctx.on('session/event', (session, event) =>
+      this.onHostEvent(session, event),
+    );
     const config = this.getConfig();
     if (config.scanOnBoot) {
       void this.bootScanLoop();
@@ -226,7 +229,9 @@ export class AutoContinueRunner {
   }
 
   dispose(): void {
+    if (this.disposed) return;
     this.disposed = true;
+    this.disposeSessionEvents();
     for (const state of this.states.values()) {
       if (state.pendingTimer !== undefined) clearTimeout(state.pendingTimer);
       if (state.loopRetryTimer !== undefined) clearTimeout(state.loopRetryTimer);

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,11 +98,19 @@ export function apply(ctx: Context): void {
     });
   });
 
+  // 引擎引用: inject 回调可能重入(依赖组合变化), 顶层 effect 在 fiber 卸载时必跑。
+  // dispose 绑定必须挂在 apply 的顶层 ctx 上——挂 inject 派生 ctx 的 effect 在 config HMR
+  // 替换行时不会执行, 悬空定时器会撞上 inactive context 炸掉整个进程。
+  let runnerRef: AutoContinueRunner | undefined;
+
   // 单实例引擎: host 进程内监听会话事件, 所有标签页共享同一个引擎。
   ctx.inject(['settings', 'agents', 'webServer'], (engineCtx) => {
+    // 回调重入时先清理旧引擎, 避免定时器与监听器叠加。
+    if (runnerRef !== undefined) runnerRef.dispose();
     const runner = new AutoContinueRunner(engineCtx, () =>
       resolveConfig(engineCtx.settings.get(settingsNamespace(AUTO_CONTINUE_NS)) as AutoContinueSettings | undefined),
     );
+    runnerRef = runner;
 
     // 状态桥: browser 侧订阅通知与运行时状态(SSE)。
     const sseClients = new Set<(data: string) => void>();
@@ -177,5 +185,13 @@ export function apply(ctx: Context): void {
         });
       },
     });
+  });
+
+  // 顶层生命周期绑定: fiber 卸载时清理引擎(定时器/监听器)。
+  // 挂在 apply 的 ctx 上保证 Cordis 一定会调用, 防止 inactive context 崩溃。
+  ctx.effect(() => () => {
+    const runner = runnerRef;
+    runnerRef = undefined;
+    if (runner !== undefined) runner.dispose();
   });
 }

--- a/tests/simulate-host.mjs
+++ b/tests/simulate-host.mjs
@@ -28,6 +28,7 @@
  *   15. 通知桥: 通知事件 + 动作(resume / pause1h / unpause / reset-stats)
  *   15b. English locale → 浏览器通知与动作本地化
  *   16. 顶层 row replacement → runner disposer 清理待发送定时器
+ *   16b. 顶层 row replacement → runner disposer 注销旧事件监听
  *   17. engine inject 重入 → 旧 runner 释放, 新 runner 单独接管
  *   18. 宽限定时器遇到 inactive settings → 异常被收口
  *   19. loop 冷却定时器遇到 inactive settings → 异常被收口
@@ -755,6 +756,25 @@ const toolResult = (callId, text, seq = 6, isError = false) => ({
   host.replacePluginRow();
   await sleep(400); // 若定时器未清理, fire 会照常执行并产生 followup
   check('row replacement 后未发送', agent.followups.length === 0);
+  await sleep(50);
+}
+
+// ---------- 测试 16b: 顶层 row replacement 注销旧 listener ----------
+{
+  console.log('测试 16b: 顶层 row replacement 注销旧 listener — 后续事件不再访问旧 context');
+  const host = startPlugin({ scanOnBoot: false });
+  const agent = host.makeAgent('s1');
+  await sleep(50);
+  host.replacePluginRow();
+  host.setContextActive(false);
+  let eventError;
+  try {
+    host.emit(agent.session, turnEnd(1, { kind: 'error', error: { code: 'UPSTREAM', message: 'late' } }));
+  } catch (error) {
+    eventError = error;
+  }
+  check('旧 listener 未访问 inactive context', eventError === undefined);
+  check('row replacement 后事件未发送', agent.followups.length === 0);
   await sleep(50);
 }
 

--- a/tests/simulate-host.mjs
+++ b/tests/simulate-host.mjs
@@ -27,6 +27,11 @@
  *   14. loop guard: 参数/结果变化 → 不打断
  *   15. 通知桥: 通知事件 + 动作(resume / pause1h / unpause / reset-stats)
  *   15b. English locale → 浏览器通知与动作本地化
+ *   16. 顶层 row replacement → runner disposer 清理待发送定时器
+ *   17. engine inject 重入 → 旧 runner 释放, 新 runner 单独接管
+ *   18. 宽限定时器遇到 inactive settings → 异常被收口
+ *   19. loop 冷却定时器遇到 inactive settings → 异常被收口
+ *   20. 通知 resume 遇到 inactive settings → 路由正常响应, 异常被收口
  * 运行: node tests/simulate-host.mjs
  */
 import { readFileSync, writeFileSync, mkdtempSync, mkdirSync, symlinkSync } from 'node:fs';
@@ -56,12 +61,53 @@ if (typeof mod.apply !== 'function') throw new Error('host bundle 未导出 appl
 
 // ---------- 假 host 环境 ----------
 function makeHost() {
-  const sessionHandlers = [];
+  const sessionHandlers = new Set();
   let config = {};
+  let configReadsBeforeFailure;
+  let contextActive = true;
   const registry = new Map();
+  const topLevelEffects = [];
+  let engineEffects = [];
+  let engineInject;
+
+  const registerEffect = (effects, start) => {
+    const cleanup = start();
+    if (typeof cleanup !== 'function') return () => {};
+    let active = true;
+    const dispose = () => {
+      if (!active) return;
+      active = false;
+      return cleanup();
+    };
+    effects.push(dispose);
+    return dispose;
+  };
+  const disposeEffects = (effects) => {
+    for (const dispose of effects.splice(0).reverse()) dispose();
+  };
+  const getConfig = () => {
+    if (!contextActive) {
+      throw new Error('cannot get required service "settings" in inactive context');
+    }
+    if (configReadsBeforeFailure !== undefined) {
+      if (configReadsBeforeFailure === 0) {
+        configReadsBeforeFailure = undefined;
+        throw new Error('cannot get required service "settings" in inactive context');
+      }
+      configReadsBeforeFailure -= 1;
+    }
+    return config;
+  };
+
   const host = {
     setConfig(patch) {
       config = { ...config, ...patch };
+    },
+    setContextActive(active) {
+      contextActive = active;
+    },
+    failConfigAfterSuccessfulReads(count) {
+      configReadsBeforeFailure = count;
     },
     emit(session, event) {
       for (const h of sessionHandlers) h(session, event);
@@ -85,48 +131,101 @@ function makeHost() {
     agent(id) {
       return registry.get(id);
     },
+    replacePluginRow() {
+      // DSH config HMR 的 row replacement 只保证顶层 fiber effect 被释放。
+      // inject 派生 context 的 effect 刻意留在另一组，避免测试把两种生命周期混为一谈。
+      disposeEffects(topLevelEffects);
+    },
+    reinjectEngine() {
+      if (engineInject === undefined) throw new Error('engine inject callback 未注册');
+      disposeEffects(engineEffects);
+      engineInject(makeEngineContext());
+    },
   };
-  const ctx = {
-    on(event, handler) {
-      if (event === 'session/event') sessionHandlers.push(handler);
-      return () => {};
-    },
-    effect(cb) {
-      // 模拟 fiber 级 effect: 收集 disposer, 供 host.dispose() 模拟热重载卸载
-      const disposer = cb();
-      host.effects = host.effects ?? [];
-      if (typeof disposer === 'function') host.effects.push(disposer);
-      return disposer ?? (() => {});
-    },
-    inject(deps, cb) {
-      cb({
-        on: (event, handler) => ctx.on(event, handler),
-        effect: (cb2) => ctx.effect(cb2),
-        settings: { register: () => {}, get: () => config },
-        agents: { get: (id) => registry.get(id), list: () => [...registry.values()] },
-        webServer: {
-          register(route) {
+
+  const makeEngineContext = () => {
+    const effects = [];
+    engineEffects = effects;
+    return {
+      on(event, handler) {
+        if (event !== 'session/event') return () => {};
+        return registerEffect(effects, () => {
+          sessionHandlers.add(handler);
+          return () => sessionHandlers.delete(handler);
+        });
+      },
+      effect: (cb) => registerEffect(effects, cb),
+      settings: { register: () => {}, get: getConfig },
+      agents: { get: (id) => registry.get(id), list: () => [...registry.values()] },
+      webServer: {
+        register(route) {
+          return registerEffect(effects, () => {
             host.routes = host.routes ?? [];
             host.routes.push(route);
-            return () => {};
-          },
+            return () => {
+              const index = host.routes.indexOf(route);
+              if (index >= 0) host.routes.splice(index, 1);
+            };
+          });
         },
-      });
+      },
+    };
+  };
+
+  const ctx = {
+    effect: (cb) => registerEffect(topLevelEffects, cb),
+    inject(deps, cb) {
+      if (deps.includes('agents')) {
+        engineInject = cb;
+        cb(makeEngineContext());
+      } else {
+        cb({ settings: { register: () => {}, get: getConfig } });
+      }
       return () => {};
     },
   };
   host.ctx = ctx;
-  host.dispose = () => {
-    // 模拟 fiber teardown: 依次执行全部 effect disposer(引擎 dispose 清理定时器)
-    for (const disposer of [...(host.effects ?? [])]) {
-      try { disposer(); } catch {}
-    }
-    host.effects = [];
-  };
   return host;
 }
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function captureConsoleErrors(run) {
+  const original = console.error;
+  const errors = [];
+  console.error = (...args) => {
+    errors.push(args.map(String).join(' '));
+  };
+  try {
+    await run();
+  } finally {
+    console.error = original;
+  }
+  return errors;
+}
+
+function postAction(host, payload) {
+  const action = host.routes?.find((route) => route.path === '/api/auto-continue-action');
+  if (action === undefined) throw new Error('动作路由未注册');
+  return new Promise((resolve) => {
+    const handlers = {};
+    const req = {
+      on(event, handler) {
+        handlers[event] = handler;
+        return req;
+      },
+    };
+    const res = {
+      writeHead() {},
+      end(body) {
+        resolve(JSON.parse(body));
+      },
+    };
+    action.handler(req, res);
+    handlers.data?.(Buffer.from(JSON.stringify(payload)));
+    handlers.end?.();
+  });
+}
 
 let failures = 0;
 function check(name, cond) {
@@ -591,35 +690,16 @@ const toolResult = (callId, text, seq = 6, isError = false) => ({
   check('收到通知帧', noticeFrame !== undefined);
   check('通知含动作', noticeFrame !== undefined && noticeFrame.includes('"action":"resume"'));
   // 动作端点: resume → 立即续跑
-  const post = (payload) =>
-    new Promise((resolve) => {
-      const handlers = {};
-      const req2 = {
-        on(ev, cb) {
-          handlers[ev] = cb;
-          return req2;
-        },
-      };
-      const res2 = {
-        writeHead() {},
-        end(body) {
-          resolve(JSON.parse(body));
-        },
-      };
-      action.handler(req2, res2);
-      handlers.data?.(Buffer.from(JSON.stringify(payload)));
-      handlers.end?.();
-    });
   const before = agent.followups.length;
-  const r1 = await post({ action: 'resume', sessionId: 's1' });
+  const r1 = await postAction(host, { action: 'resume', sessionId: 's1' });
   check('resume 动作 ok', r1.ok === true);
   await sleep(100);
   check('立即续跑发送', agent.followups.length === before + 1);
-  const r2 = await post({ action: 'pause1h', sessionId: 's1' });
+  const r2 = await postAction(host, { action: 'pause1h', sessionId: 's1' });
   check('pause1h 动作 ok', r2.ok === true);
-  const r3 = await post({ action: 'unpause', sessionId: 's1' });
+  const r3 = await postAction(host, { action: 'unpause', sessionId: 's1' });
   check('unpause 动作 ok', r3.ok === true);
-  const r4 = await post({ action: 'reset-stats' });
+  const r4 = await postAction(host, { action: 'reset-stats' });
   check('reset-stats 动作 ok', r4.ok === true);
   await sleep(50);
 }
@@ -664,17 +744,106 @@ const toolResult = (callId, text, seq = 6, isError = false) => ({
   await sleep(50);
 }
 
-// ---------- 测试 16: 卸载(热重载)清理定时器 — dispose 后不再 fire ----------
+// ---------- 测试 16: 顶层 row replacement 清理定时器 ----------
 {
-  console.log('测试 16: 卸载(热重载)清理定时器 — dispose 后不再 fire');
+  console.log('测试 16: 顶层 row replacement 清理定时器 — 替换后不再 fire');
   const host = startPlugin({ scanOnBoot: false });
   const agent = host.makeAgent('s1');
   await sleep(50);
   host.emit(agent.session, turnEnd(1, { kind: 'error', error: { code: 'UPSTREAM', message: 'boom' } }));
   await sleep(100); // 宽限期(200ms)内卸载, 模拟 config HMR 行替换
-  host.dispose();
+  host.replacePluginRow();
   await sleep(400); // 若定时器未清理, fire 会照常执行并产生 followup
-  check('卸载后未发送', agent.followups.length === 0);
+  check('row replacement 后未发送', agent.followups.length === 0);
+  await sleep(50);
+}
+
+// ---------- 测试 17: inject 重入替换旧 runner ----------
+{
+  console.log('测试 17: inject 重入替换旧 runner — 旧定时器取消且新 runner 接管');
+  const host = startPlugin({ scanOnBoot: false });
+  const agent = host.makeAgent('s1');
+  await sleep(50);
+  host.emit(agent.session, turnEnd(1, { kind: 'error', error: { code: 'UPSTREAM', message: 'old' } }));
+  await sleep(100);
+  host.reinjectEngine();
+  await sleep(300);
+  check('重入后旧 runner 未发送', agent.followups.length === 0);
+  host.emit(agent.session, turnEnd(2, { kind: 'error', error: { code: 'UPSTREAM', message: 'new' } }));
+  await sleep(300);
+  check('新 runner 正常接管', agent.followups.length === 1);
+  await sleep(50);
+}
+
+// ---------- 测试 18: 宽限定时器遇到 inactive context ----------
+{
+  console.log('测试 18: 宽限定时器遇到 inactive context — 记录异常且进程继续');
+  const host = startPlugin({ scanOnBoot: false, graceMs: 100 });
+  const agent = host.makeAgent('s1');
+  await sleep(50);
+  host.emit(agent.session, turnEnd(1, { kind: 'error', error: { code: 'UPSTREAM', message: 'boom' } }));
+  const errors = await captureConsoleErrors(async () => {
+    host.setContextActive(false);
+    await sleep(200);
+  });
+  check(
+    '定时发送异常已记录',
+    errors.some((line) => line.includes('定时发送异常 s1') && line.includes('inactive context')),
+  );
+  check('inactive context 时未发送', agent.followups.length === 0);
+  await sleep(50);
+}
+
+// ---------- 测试 19: loop 冷却定时器遇到 inactive context ----------
+{
+  console.log('测试 19: loop 冷却定时器遇到 inactive context — 记录异常且进程继续');
+  const host = startPlugin({
+    scanOnBoot: false,
+    loopRepeatText: 2,
+    graceMs: 100,
+    cooldownMs: 300,
+  });
+  const agent = host.makeAgent('s1');
+  await sleep(50);
+  host.emit(agent.session, turnStart(1));
+  const repeated =
+    'This deliberately repeated assistant response is long enough for exact-text loop detection.';
+  host.emit(agent.session, assistantMsg(repeated, 10));
+  host.emit(agent.session, assistantMsg(repeated, 11));
+  await sleep(50);
+  check('loop guard 已打断', agent.cancels.length === 1);
+  host.emit(agent.session, turnEnd(1, { kind: 'aborted', reason: { kind: 'human' } }));
+  const errors = await captureConsoleErrors(async () => {
+    host.setContextActive(false);
+    await sleep(400);
+  });
+  check(
+    'loop 重启异常已记录',
+    errors.some((line) => line.includes('loop 重启异常 s1') && line.includes('inactive context')),
+  );
+  check('inactive context 时 loop 未重启', agent.followups.length === 0);
+  await sleep(50);
+}
+
+// ---------- 测试 20: 通知 resume 遇到 inactive context ----------
+{
+  console.log('测试 20: 通知 resume 遇到 inactive context — 路由仍响应且异常被收口');
+  const host = startPlugin({ scanOnBoot: false });
+  const agent = host.makeAgent('s1');
+  await sleep(50);
+  // 通知动作先写一条 debug log；让这次读取成功，再让 resumeNow -> fire 的读取失败。
+  host.failConfigAfterSuccessfulReads(1);
+  let response;
+  const errors = await captureConsoleErrors(async () => {
+    response = await postAction(host, { action: 'resume', sessionId: 's1' });
+    await sleep(50);
+  });
+  check('resume 路由仍返回 ok', response?.ok === true);
+  check(
+    '手动续跑异常已记录',
+    errors.some((line) => line.includes('手动续跑异常 s1') && line.includes('inactive context')),
+  );
+  check('inactive context 时 resume 未发送', agent.followups.length === 0);
   await sleep(50);
 }
 

--- a/tests/simulate-host.mjs
+++ b/tests/simulate-host.mjs
@@ -91,9 +91,17 @@ function makeHost() {
       if (event === 'session/event') sessionHandlers.push(handler);
       return () => {};
     },
+    effect(cb) {
+      // 模拟 fiber 级 effect: 收集 disposer, 供 host.dispose() 模拟热重载卸载
+      const disposer = cb();
+      host.effects = host.effects ?? [];
+      if (typeof disposer === 'function') host.effects.push(disposer);
+      return disposer ?? (() => {});
+    },
     inject(deps, cb) {
       cb({
         on: (event, handler) => ctx.on(event, handler),
+        effect: (cb2) => ctx.effect(cb2),
         settings: { register: () => {}, get: () => config },
         agents: { get: (id) => registry.get(id), list: () => [...registry.values()] },
         webServer: {
@@ -108,6 +116,13 @@ function makeHost() {
     },
   };
   host.ctx = ctx;
+  host.dispose = () => {
+    // 模拟 fiber teardown: 依次执行全部 effect disposer(引擎 dispose 清理定时器)
+    for (const disposer of [...(host.effects ?? [])]) {
+      try { disposer(); } catch {}
+    }
+    host.effects = [];
+  };
   return host;
 }
 
@@ -646,6 +661,20 @@ const toolResult = (callId, text, seq = 6, isError = false) => ({
       notices.includes('Resume now') &&
       notices.includes('Pause this session for 1 hour'),
   );
+  await sleep(50);
+}
+
+// ---------- 测试 16: 卸载(热重载)清理定时器 — dispose 后不再 fire ----------
+{
+  console.log('测试 16: 卸载(热重载)清理定时器 — dispose 后不再 fire');
+  const host = startPlugin({ scanOnBoot: false });
+  const agent = host.makeAgent('s1');
+  await sleep(50);
+  host.emit(agent.session, turnEnd(1, { kind: 'error', error: { code: 'UPSTREAM', message: 'boom' } }));
+  await sleep(100); // 宽限期(200ms)内卸载, 模拟 config HMR 行替换
+  host.dispose();
+  await sleep(400); // 若定时器未清理, fire 会照常执行并产生 followup
+  check('卸载后未发送', agent.followups.length === 0);
   await sleep(50);
 }
 


### PR DESCRIPTION
## Problem

The `AutoContinueRunner` creates pending timers (the schedule grace timer and the loop-retry timer) but was never bound to any lifecycle cleanup. When the plugin row is replaced by config HMR (editing `cordis.patch.yml`, plugin reinstall, etc.), the old fiber is torn down but its timers keep running. The timer callback then calls `fire()` -> `getConfig()` on an inactive context, throwing an uncaught error:

```
Error: cannot get required service "settings" in inactive context
    at AutoContinueRunner.getConfig
    at AutoContinueRunner.fire
    at Timeout._onTimeout
```

which crashes the entire DSH host process. Reproduced twice in a live deployment (repeated hot reloads), each time killing the host.

## Changes

- `src/index.ts`: keep the runner in a fiber-level reference; dispose the previous runner when the inject callback re-enters; bind dispose to a **top-level** `ctx.effect` so Cordis guarantees cleanup on fiber teardown. (An effect on the inject-derived context does NOT run on HMR row replacement — verified empirically — hence the top-level binding.)
- `src/host/engine.ts`: wrap the three timer/async callbacks (grace-timer `fire`, loop-retry `schedule`, `resumeNow`) in try/catch fuses so any future lifecycle race degrades to a log line instead of an uncaught exception that kills the process.

`lib/index.js` is the rebuilt committed artifact (client bundle unchanged).

## Verification

- Repeated config-HMR row replacements that previously reproduced the crash now complete without a crash; the host process survives and the engine restarts normally.
- No functional behavior changes: continue text, cooldown, consecutive cap, idempotency guard, loop guard, and scan logic are untouched.

## Sourcery 摘要

确保自动继续运行器随其 fiber 一起释放，并隔离生命周期竞态，从而避免热重载导致宿主进程崩溃。

Bug 修复：
- 防止过期的自动继续计时器在 fiber 拆除和配置热重载期间导致宿主崩溃。
- 将计时器和异步运行器故障作为已记录的错误处理，而不是未捕获的进程级异常。

增强功能：
- 将自动继续运行器的生命周期与 fiber 绑定，并在注入的依赖发生变化时替换或释放现有运行器。

杂项：
- 使用生命周期和错误处理修复重新构建已提交的库构建产物。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

确保自动延续运行器能够与其 fiber 和 isolate 的生命周期竞态正确清理，从而在热重载期间保持宿主进程稳定。

Bug 修复：
- 防止过时的自动延续计时器在 fiber 拆除后触发，避免在配置热重载期间导致宿主进程崩溃。
- 将计时器和异步运行器的生命周期错误作为已记录的失败进行处理，而不是未捕获的进程级异常。

改进：
- 将自动延续运行器的生命周期与 fiber 绑定，并在注入的依赖项发生变化时替换或释放该运行器。

构建：
- 重新构建已提交的库构件。

测试：
- 添加宿主模拟测试，验证热重载期间的释放操作会取消待处理的延续活动。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

确保自动继续运行器与其 fiber 一起释放，并防止生命周期竞态导致宿主进程崩溃。

错误修复：
- 防止过时的自动继续计时器在 fiber 拆卸和配置热重载期间导致宿主崩溃。
- 将计时器和异步生命周期错误作为已记录的失败进行处理，而不是未捕获的进程级异常。

增强功能：
- 将自动继续运行器的生命周期绑定到所属 fiber，并在重新注入依赖项时替换过时的运行器。

构建：
- 重新构建已提交的库构件。

测试：
- 扩展宿主模拟测试的覆盖范围，涵盖热重载场景下的运行器释放、重新注入以及非活动上下文错误处理。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

确保自动继续运行器与其 fiber 一同释放，并隔离生命周期竞态，避免热重载导致宿主进程崩溃。

Bug 修复：
- 防止过期的自动继续计时器和事件监听器在热重载期间访问非活动上下文，从而导致宿主进程崩溃。
- 将计时器和异步生命周期竞态作为已记录的错误处理，而不是未捕获的进程级异常。

增强功能：
- 将自动继续运行器的生命周期绑定到其 fiber，并在注入的依赖发生变化时替换或释放该运行器。

构建：
- 重新构建已提交的库构件。

测试：
- 扩展宿主模拟测试，覆盖热重载期间的运行器释放、重新注入、监听器清理以及非活动上下文错误处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure the auto-continue runner is disposed with its fiber and isolate lifecycle races so hot reloads cannot crash the host process.

Bug Fixes:
- Prevent stale auto-continue timers and event listeners from accessing inactive contexts during hot reload and crashing the host process.
- Handle timer and asynchronous lifecycle races as logged errors instead of uncaught process-level exceptions.

Enhancements:
- Bind the auto-continue runner lifecycle to its fiber and replace or dispose it when injected dependencies change.

Build:
- Rebuild the committed library artifact.

Tests:
- Expand host simulation coverage for runner disposal, reinjection, listener cleanup, and inactive-context error handling during hot reload.

</details>

</details>

</details>

</details>