### PR TITLE
fix: bind notification actions to sessions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -621,6 +621,7 @@ ${event.data.arguments}`;
       this.bumpStat({ skipped: 1, code: failure.code });
       if (config.notify) {
         this.notify(
+          sessionId,
           copy.notContinuedTitle,
           copy.permanentErrorBody(sessionId, summary),
           this.notifyOptions(sessionId, config.locale)
@@ -666,11 +667,12 @@ ${event.data.arguments}`;
     }
   }
   /** 通知桥: 产生一条通知事件, SSE 端点推给 browser 侧展示。 */
-  notify(title, body, options) {
+  notify(sessionId, title, body, options) {
     const notice = {
       id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
       title,
       body,
+      sessionId,
       ...options?.actions !== void 0 && options.actions.length > 0 ? { actions: options.actions } : { actions: [] },
       at: Date.now()
     };
@@ -803,6 +805,7 @@ ${event.data.arguments}`;
       if (config.notify) {
         const copy = NOTICE_COPY[config.locale];
         this.notify(
+          sessionId,
           copy.continuedTitle,
           copy.continuedBody(sessionId, text, state.consecutive),
           this.notifyOptions(sessionId, config.locale)
@@ -814,6 +817,7 @@ ${event.data.arguments}`;
         if (config.notify) {
           const copy = NOTICE_COPY[config.locale];
           this.notify(
+            sessionId,
             copy.stoppedTitle,
             copy.stoppedBody(sessionId, state.consecutive),
             this.notifyOptions(sessionId, config.locale)

--- a/lib/types/host/engine.d.ts
+++ b/lib/types/host/engine.d.ts
@@ -21,7 +21,7 @@ export interface HostNotice {
     title: string;
     body: string;
     /** 会话 id(通知按钮「立即续跑 / 暂停该会话」作用于它)。 */
-    sessionId?: SessionId;
+    sessionId: SessionId;
     actions: NotifyAction[];
     /** 产生时间。 */
     at: number;

--- a/src/host/engine.ts
+++ b/src/host/engine.ts
@@ -79,7 +79,7 @@ export interface HostNotice {
   title: string;
   body: string;
   /** 会话 id(通知按钮「立即续跑 / 暂停该会话」作用于它)。 */
-  sessionId?: SessionId;
+  sessionId: SessionId;
   actions: NotifyAction[];
   /** 产生时间。 */
   at: number;
@@ -505,6 +505,7 @@ export class AutoContinueRunner {
       this.bumpStat({ skipped: 1, code: failure.code });
       if (config.notify) {
         this.notify(
+          sessionId,
           copy.notContinuedTitle,
           copy.permanentErrorBody(sessionId, summary),
           this.notifyOptions(sessionId, config.locale),
@@ -563,11 +564,17 @@ export class AutoContinueRunner {
   }
 
   /** 通知桥: 产生一条通知事件, SSE 端点推给 browser 侧展示。 */
-  private notify(title: string, body: string, options?: NotifyOptions): void {
+  private notify(
+    sessionId: SessionId,
+    title: string,
+    body: string,
+    options?: NotifyOptions,
+  ): void {
     const notice: HostNotice = {
       id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
       title,
       body,
+      sessionId,
       ...(options?.actions !== undefined && options.actions.length > 0
         ? { actions: options.actions }
         : { actions: [] }),
@@ -720,6 +727,7 @@ export class AutoContinueRunner {
       if (config.notify) {
         const copy = NOTICE_COPY[config.locale];
         this.notify(
+          sessionId,
           copy.continuedTitle,
           copy.continuedBody(sessionId, text, state.consecutive),
           this.notifyOptions(sessionId, config.locale),
@@ -731,6 +739,7 @@ export class AutoContinueRunner {
         if (config.notify) {
           const copy = NOTICE_COPY[config.locale];
           this.notify(
+            sessionId,
             copy.stoppedTitle,
             copy.stoppedBody(sessionId, state.consecutive),
             this.notifyOptions(sessionId, config.locale),

--- a/tests/simulate-host.mjs
+++ b/tests/simulate-host.mjs
@@ -690,9 +690,11 @@ const toolResult = (callId, text, seq = 6, isError = false) => ({
   const noticeFrame = frames.find((f) => f.includes('"type":"notice"'));
   check('收到通知帧', noticeFrame !== undefined);
   check('通知含动作', noticeFrame !== undefined && noticeFrame.includes('"action":"resume"'));
+  const notice = noticeFrame === undefined ? undefined : JSON.parse(noticeFrame.slice(6)).notice;
+  check('通知携带动作目标会话', notice?.sessionId === 's1');
   // 动作端点: resume → 立即续跑
   const before = agent.followups.length;
-  const r1 = await postAction(host, { action: 'resume', sessionId: 's1' });
+  const r1 = await postAction(host, { action: 'resume', sessionId: notice?.sessionId });
   check('resume 动作 ok', r1.ok === true);
   await sleep(100);
   check('立即续跑发送', agent.followups.length === before + 1);


### PR DESCRIPTION
## Summary

- include the target session ID in every host notification sent over the SSE bridge
- make `HostNotice.sessionId` required so future notification call sites cannot omit it
- verify the resume action round trip using the session ID parsed from the real SSE notice

## Problem

The browser bridge only posts notification actions when `notice.sessionId` is present. The host declared that field but never populated it, so the **Resume now** and **Pause this session for 1 hour** buttons silently did nothing. Existing tests hard-coded `s1` when posting an action and therefore missed the broken bridge payload.

## Verification

- `npm test`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

## Sourcery 摘要

将通知操作绑定到其来源会话，并验证端到端的会话定位行为。

错误修复：
- 将主机通知操作绑定到生成每条通知的会话，以确保恢复和暂停操作发送到预期的会话。

增强功能：
- 要求每条主机通知都包含其目标会话 ID，并使用从接收到的通知中获取的 ID 验证 SSE 操作往返流程。

测试：
- 更新主机模拟，以验证通知会话 ID，并使用解析出的目标会话提交操作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bind notification actions to their originating sessions and verify the end-to-end session targeting behavior.

Bug Fixes:
- Bind host notification actions to the session that generated each notification so resume and pause actions reach the intended session.

Enhancements:
- Require every host notification to include its target session ID and validate the SSE action round trip using the ID from the received notice.

Tests:
- Update the host simulation to verify notification session IDs and submit actions using the parsed target session.

</details>