### PR TITLE
fix: restore boot scan on DSH 0.1.2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -301,6 +301,12 @@ var NOTICE_COPY = {
     stoppedBody: (sessionId, count) => `${sessionId}: ${count} consecutive failures; manual intervention required`
   }
 };
+function snapshotSessionEvents(session) {
+  const compatible = session;
+  if (typeof compatible.snapshotEvents === "function") return compatible.snapshotEvents();
+  if (compatible.events !== void 0) return compatible.events;
+  throw new TypeError("session exposes neither snapshotEvents() nor events");
+}
 var AutoContinueRunner = class {
   /**
    * @param ctx - host plugin context (agents registry, session events, settings).
@@ -892,7 +898,7 @@ ${event.data.arguments}`;
     for (const agent of this.ctx.agents.list()) {
       const session = agent.session;
       if (session.header.origin === "subagent") continue;
-      candidates.push({ sessionId: session.id, events: session.events });
+      candidates.push({ sessionId: session.id, events: snapshotSessionEvents(session) });
     }
     for (const candidate of candidates.slice(0, config.scanLimit)) {
       if (this.disposed) return true;

--- a/src/host/engine.ts
+++ b/src/host/engine.ts
@@ -96,6 +96,20 @@ export interface HostNotice {
 /** SSE 帧外壳: `{ rpcId, payload }`。 */
 type FrameEnvelope<T> = { payload: T };
 
+/** Session history APIs across the supported DSH host releases. */
+type CompatibleSession = Session & {
+  readonly events?: readonly SessionEvent[];
+  snapshotEvents?: () => readonly SessionEvent[];
+};
+
+/** Read one stable event-log snapshot on both legacy and DSH 0.1.2 hosts. */
+function snapshotSessionEvents(session: Session): readonly SessionEvent[] {
+  const compatible = session as CompatibleSession;
+  if (typeof compatible.snapshotEvents === 'function') return compatible.snapshotEvents();
+  if (compatible.events !== undefined) return compatible.events;
+  throw new TypeError('session exposes neither snapshotEvents() nor events');
+}
+
 /**
  * 事件流泵: 带指数退避的 SSE 重连循环。
  * - 从未收到任何帧(宿主未就绪): 退避重试, 不触发扫描
@@ -831,7 +845,7 @@ export class AutoContinueRunner {
     for (const agent of this.ctx.agents.list()) {
       const session = agent.session;
       if (session.header.origin === 'subagent') continue; // 子代理由父代理处理
-      candidates.push({ sessionId: session.id, events: session.events });
+      candidates.push({ sessionId: session.id, events: snapshotSessionEvents(session) });
     }
     for (const candidate of candidates.slice(0, config.scanLimit)) {
       if (this.disposed) return true;

--- a/tests/simulate-host.mjs
+++ b/tests/simulate-host.mjs
@@ -10,7 +10,7 @@
  *   2. 宽限期内 turn/start → 取消
  *   3. aborted(用户停止)→ 不发送
  *   4. 连续次数上限
- *   5. 启动扫描: 最后回合 interrupted → 自动续跑
+ *   5. 启动扫描: 兼容旧 events 属性与新 snapshotEvents() API
  *   6. 错误分类: 永久性跳过, 临时性续跑
  *   6b. provider 专属错误的用户自定义可恢复匹配
  *   7. continueText 模板
@@ -113,8 +113,14 @@ function makeHost() {
     emit(session, event) {
       for (const h of sessionHandlers) h(session, event);
     },
-    makeAgent(id, { events = [], origin } = {}) {
-      const session = { id, header: { origin }, events };
+    makeAgent(id, { events = [], origin, eventApi = 'legacy' } = {}) {
+      const session = { id, header: { origin } };
+      if (eventApi === 'snapshot') {
+        const snapshot = Object.freeze([...events]);
+        session.snapshotEvents = () => snapshot;
+      } else {
+        session.events = events;
+      }
       const agent = {
         session,
         followups: [],
@@ -394,14 +400,34 @@ const toolResult = (callId, text, seq = 6, isError = false) => ({
   await sleep(50);
 }
 
-// ---------- 测试 5: 启动扫描 interrupted ----------
+// ---------- 测试 5: 启动扫描 interrupted(旧 API) ----------
 {
-  console.log('测试 5: 启动扫描发现最近 interrupted 回合 → 自动继续');
+  console.log('测试 5: 启动扫描通过旧 events API 发现最近 interrupted 回合');
   const now = Date.now();
   const host = makeHost();
   const agent = host.makeAgent('s1', {
     events: [
       { type: 'turn/end', seq: 2, time: now - 60_000, data: { turn: 1, reason: { kind: 'interrupted' } } },
+    ],
+  });
+  host.setConfig({ ...FAST, scanOnBoot: true });
+  mod.apply(host.ctx);
+  await sleep(1000);
+  check('已发送', agent.followups.length === 1);
+  await sleep(50);
+}
+
+// ---------- 测试 5b: 启动扫描 interrupted(DSH 0.1.2 API) ----------
+{
+  console.log('测试 5b: 启动扫描通过 snapshotEvents() 发现最近 interrupted 回合');
+  const now = Date.now();
+  const host = makeHost();
+  const agent = host.makeAgent('s1', {
+    eventApi: 'snapshot',
+    events: [
+      { type: 'turn/start', seq: 0, time: now - 61_000, data: { turn: 1 } },
+      { type: 'turn/end', seq: 1, time: now - 60_000, data: { turn: 1, reason: { kind: 'interrupted' } } },
+      { type: 'session/end-seed', seq: 2, time: now - 59_000, data: {} },
     ],
   });
   host.setConfig({ ...FAST, scanOnBoot: true });


### PR DESCRIPTION
## Summary

- read session history through snapshotEvents() on DSH 0.1.2
- retain the legacy events fallback for earlier supported DSH releases
- cover both host APIs in the boot-scan regression suite and rebuild the committed host bundle

## Root cause

DSH 0.1.2 replaced the public session.events array with snapshotEvents(). The boot scan still read session.events, so its reverse traversal dereferenced undefined.length and retried forever without resuming the interrupted session.

## Verification

- npm run build
- npm run typecheck
- npm test
- git diff --check

Closes #28

## Sourcery 摘要

恢复在受支持的 DSH 主机版本启动期间自动继续中断会话的功能。

错误修复：
- 通过支持 DSH 0.1.2 的 snapshotEvents() 会话历史 API，恢复启动时的中断会话扫描。
- 保持与较早版本主机的兼容性，这些主机通过旧版 events 属性提供会话历史记录。

构建：
- 使用兼容的会话历史处理逻辑重新构建已提交的主机包。

测试：
- 扩展启动扫描回归测试，覆盖旧版 events 和 snapshotEvents() 主机 API。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore automatic continuation of interrupted sessions during boot across supported DSH host releases.

Bug Fixes:
- Restore boot-time interrupted-session scanning on DSH 0.1.2 by supporting its snapshotEvents() session history API.
- Preserve compatibility with earlier hosts that expose session history through the legacy events property.

Build:
- Rebuild the committed host bundle with the compatible session history handling.

Tests:
- Extend boot-scan regression coverage to exercise both legacy events and snapshotEvents() host APIs.

</details>